### PR TITLE
Fixed gradle baseName issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,11 +83,15 @@ project(':simulator') {
     }
 
     distZip {
-        configure distSettings
+        baseName = 'simblock'
+        exclude('output/graph/*.*')
+        exclude('output/*.*')
     }
 
     distTar {
-        configure distSettings
+        baseName = 'simblock'
+        exclude('output/graph/*.*')
+        exclude('output/*.*')
     }
 
     startScripts {

--- a/build.gradle
+++ b/build.gradle
@@ -77,21 +77,17 @@ project(':simulator') {
     mainClassName = 'simblock.simulator.Main'
 
     def distSettings = {
-        baseName = 'simblock'
+        archivesBaseName = 'simblock'
         exclude('output/graph/*.*')
         exclude('output/*.*')
     }
 
     distZip {
-        baseName = 'simblock'
-        exclude('output/graph/*.*')
-        exclude('output/*.*')
+        configure distSettings
     }
 
     distTar {
-        baseName = 'simblock'
-        exclude('output/graph/*.*')
-        exclude('output/*.*')
+        configure distSettings
     }
 
     startScripts {


### PR DESCRIPTION
**Problem:**
When building the simulator fails with: 
 
>Where:
>Build file 'simblock/build.gradle' line: 80

>* What went wrong:
>A problem occurred evaluating root project 'simblock'.
>> Could not set unknown property 'baseName' for task ':simulator:distZip' of type org.gradle.api.tasks.bundling.Zip.

**FIX:**  change line 80 from '`baseName`' to '`archivesBaseName`' 