### PR TITLE
Change baseName to archiveBaseName since Gradle6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ project(':simulator') {
     mainClassName = 'simblock.simulator.Main'
 
     def distSettings = {
-        baseName = 'simblock'
+        archiveBaseName = 'simblock'
         exclude('output/graph/*.*')
         exclude('output/*.*')
     }


### PR DESCRIPTION
From Gradle 6.0, you need to change `baseName` to `archiveBaseName` for it to work.