### PR TITLE
Update Miner Hashrate Data Type from int to long

### DIFF
--- a/simulator/src/main/java/simblock/settings/SimulationConfiguration.java
+++ b/simulator/src/main/java/simblock/settings/SimulationConfiguration.java
@@ -41,13 +41,13 @@ public class SimulationConfiguration {
    * The average mining power of each node. Mining power corresponds to Hash Rate in Bitcoin, and is
    * the number of mining (hash calculation) executed per millisecond.
    */
-  public static final int AVERAGE_MINING_POWER = 400000;
+  public static final long AVERAGE_MINING_POWER = 400000;
 
   /**
    * The mining power of each node is determined randomly according to the normal distribution whose
    * average is AVERAGE_MINING_POWER and standard deviation is STDEV_OF_MINING_POWER.
    */
-  public static final int STDEV_OF_MINING_POWER = 100000;
+  public static final long STDEV_OF_MINING_POWER = 100000;
 
   /** The constant AVERAGE_COINS. */
   // TODO

--- a/simulator/src/main/java/simblock/simulator/Main.java
+++ b/simulator/src/main/java/simblock/simulator/Main.java
@@ -299,10 +299,10 @@ public class Main {
    *
    * @return the number of hash calculations executed per millisecond.
    */
-  public static int genMiningPower() {
+  public static long genMiningPower() {
     double r = random.nextGaussian();
 
-    return Math.max((int) (r * STDEV_OF_MINING_POWER + AVERAGE_MINING_POWER), 1);
+    return Math.max((long) (r * STDEV_OF_MINING_POWER + AVERAGE_MINING_POWER), 1);
   }
 
   /**
@@ -311,13 +311,13 @@ public class Main {
    * @return the node that will mint the genesis block
    */
   public static Node getGenesisMinter() {
-    int totalMiningPower = 0;
+    long totalMiningPower = 0;
     for (Node node : getSimulatedNodes()) {
       totalMiningPower += node.getMiningPower();
     }
 
-    int randomValue = random.nextInt(totalMiningPower);
-    int cumulativeMiningPower = 0;
+    long randomValue = (long) (random.nextDouble() * totalMiningPower);
+    long cumulativeMiningPower = 0;
 
     for (Node node : getSimulatedNodes()) {
       cumulativeMiningPower += node.getMiningPower();


### PR DESCRIPTION
### Description
This pull request updates the miner's hashrate data type from `int` to `long` to accommodate larger values and prevent potential overflow issues.

### Changes Made
- Modified the type of hashrate data in the `genMiningPower` and `getGenesisMinter` functions in `Main.java`.

#### Note
In the `getGenesisMinter` method, `random.nextDouble` is used internally, which may cause precision loss. This should be taken into account when dealing with very high hashrate values.
