### PR TITLE
Update network parameters for 2024

### DIFF
--- a/simulator/src/main/java/simblock/settings/NetworkConfiguration.java
+++ b/simulator/src/main/java/simblock/settings/NetworkConfiguration.java
@@ -52,51 +52,54 @@ public class NetworkConfiguration {
     {151, 252, 301, 58, 12, 126},
     {189, 294, 322, 198, 126, 16}
   };
+  /**
+   * LATENCY[i][j] is average latency from REGION_LIST[i] to REGION_LIST[j] Unit: millisecond, for
+   * year 2024
+   */
+  private static final long[][] LATENCY_2024 = {
+    {34, 120, 152, 219, 146, 184},
+    {121, 20, 208, 212, 282, 279},
+    {152, 208, 13, 351, 289, 317},
+    {219, 206, 352, 109, 93, 188},
+    {146, 283, 289, 93, 0, 123},
+    {184, 278, 317, 188, 123, 10}
+  };
 
   /** List of latency assigned to each region. (unit: millisecond) */
   public static final long[][] LATENCY = LATENCY_2019;
 
-  /**
-   * List of download bandwidth assigned to each region, and last element is Inter-regional
-   * bandwidth. (unit: bit per second) for year 2015
-   */
+  /** List of download bandwidth assigned to each region. (unit: bit per second) for year 2015 */
   private static final long[] DOWNLOAD_BANDWIDTH_2015 = {
-    25000000, 24000000, 6500000, 10000000, 17500000, 14000000, 6 * 1000000
+    25000000, 24000000, 6500000, 10000000, 17500000, 14000000
   };
-  /**
-   * List of download bandwidth assigned to each region, and last element is Inter-regional
-   * bandwidth. (unit: bit per second) for year 2019
-   */
+  /** List of download bandwidth assigned to each region. (unit: bit per second) for year 2019 */
   private static final long[] DOWNLOAD_BANDWIDTH_2019 = {
-    52000000, 40000000, 18000000, 22800000, 22800000, 29900000, 6 * 1000000
+    52000000, 40000000, 18000000, 22800000, 22800000, 29900000
+  };
+  /** List of download bandwidth assigned to each region. (unit: bit per second) for year 2024 */
+  private static final long[] DOWNLOAD_BANDWIDTH_2024 = {
+    185000000, 123000000, 147000000, 135000000, 84000000, 154000000
   };
 
-  /**
-   * List of download bandwidth assigned to each region, and last element is Inter-regional
-   * bandwidth. (unit: bit per second)
-   */
+  /** List of download bandwidth assigned to each region. (unit: bit per second) */
   public static final long[] DOWNLOAD_BANDWIDTH = DOWNLOAD_BANDWIDTH_2019;
 
-  /**
-   * List of upload bandwidth assigned to each region. (unit: bit per second), and last element is
-   * Inter-regional bandwidth for year 2015
-   */
+  /** List of upload bandwidth assigned to each region. (unit: bit per second) for year 2015 */
   private static final long[] UPLOAD_BANDWIDTH_2015 = {
     4700000, 8100000, 1800000, 5300000, 3400000, 5200000, 6 * 1000000
   };
 
-  /**
-   * List of upload bandwidth assigned to each region. (unit: bit per second), and last element is
-   * Inter-regional bandwidth for year 2019
-   */
+  /** List of upload bandwidth assigned to each region. (unit: bit per second) for year 2019 */
   private static final long[] UPLOAD_BANDWIDTH_2019 = {
     19200000, 20700000, 5800000, 15700000, 10200000, 11300000, 6 * 1000000
   };
 
-  /**
-   * List of upload bandwidth assigned to each region. (unit: bit per second), and last element is
-   * Inter-regional bandwidth.
-   */
+  /** List of upload bandwidth assigned to each region. (unit: bit per second) for year 2024 */
+  private static final long[] UPLOAD_BANDWIDTH_2024 = {
+    36000000, 36000000, 54000000, 49000000, 23000000, 20000000, 6 * 1000000
+  };
+
+  /** List of upload bandwidth assigned to each region. (unit: bit per second) */
   public static final long[] UPLOAD_BANDWIDTH = UPLOAD_BANDWIDTH_2019;
 
   /** Region distribution Bitcoin 2015. */
@@ -109,6 +112,12 @@ public class NetworkConfiguration {
   private static final double[] REGION_DISTRIBUTION_BITCOIN_2019 = {
     0.3316, 0.4998, 0.0090,
     0.1177, 0.0224, 0.0195
+  };
+
+  /** Region distribution Bitcoin 2024. */
+  private static final double[] REGION_DISTRIBUTION_BITCOIN_2024 = {
+    0.2944, 0.5718, 0.0162,
+    0.0822, 0.0166, 0.0188
   };
 
   /** Region distribution Litecoin. */

--- a/simulator/src/main/java/simblock/settings/SimulationConfiguration.java
+++ b/simulator/src/main/java/simblock/settings/SimulationConfiguration.java
@@ -61,14 +61,17 @@ public class SimulationConfiguration {
 
   /** The block height when a simulation ends. */
   // TODO revert
-  // public static final int END_BLOCK_HEIGHT = 100;
   public static final int END_BLOCK_HEIGHT = 3;
 
   /** Block size. (unit: byte). */
   public static final long BLOCK_SIZE = 535000; // 6110;//8000;//535000;//0.5MB
 
+  /** The usage rate of compact block relay (CBR) protocol for year 2019. */
+  public static final float CBR_USAGE_RATE_2019 = 0.964f;
+  /** The usage rate of compact block relay (CBR) protocol for year 2024. */
+  public static final float CBR_USAGE_RATE_2024 = 0.996f;
   /** The usage rate of compact block relay (CBR) protocol. */
-  public static final float CBR_USAGE_RATE = 0.964f;
+  public static final float CBR_USAGE_RATE = CBR_USAGE_RATE_2019;
   /** The rate of nodes that cause churn. */
   public static final float CHURN_NODE_RATE = 0.976f;
   /** Compact block size. (unit: byte) */
@@ -81,33 +84,22 @@ public class SimulationConfiguration {
   /** The distribution of data size that a control node receives when fails CBR. */
   public static final float[] CBR_FAILURE_BLOCK_SIZE_DISTRIBUTION_FOR_CONTROL_NODE = {
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f,
     0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
-        0.01f, 0.01f
+    0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
+    0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f, 0.01f,
+    0.01f, 0.01f
   };
   /** The distribution of data size that a churn node receives when fails CBR. */
   public static final float[] CBR_FAILURE_BLOCK_SIZE_DISTRIBUTION_FOR_CHURN_NODE = {


### PR DESCRIPTION
## Problem
The current network parameters are outdated as they are from 2024.

## Solution
The following parameters were added or changed:

### File: `NetworkConfiguration.java`
- `LATENCY_2024`
- `DOWNLOAD_BANDWIDTH_2024`
- `UPLOAD_BANDWIDTH_2024`
- `REGION_DISTRIBUTION_BITCOIN_2024`

### File: `SimulationConfiguration.java`
- `CBR_USAGE_RATE_2024`

## Notes
- The previous `BANDWIDTH` parameters had 7 elements for 6 regions. The comment mentioned internal-bandwidth, but the 7th element was not used in the SimBlock implementation. It turned out that the seventh element was prepared as "other" for bandwidth outside the 6 regions, but someone misunderstood and left the comment as internal-bandwidth. Therefore, the seventh element was removed from the 2015 and 2019 parameters as well. Since these parameters were not used in the implementation, this change does not affect simulation experiments using the 2015 and 2019 parameters.